### PR TITLE
Compiled mode: Run tests with custom system image

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -6,6 +6,14 @@ lazy = true
     sha256 = "5a588162779446d8e5235bf6fc97588d1e197f44cf64e3a1f88ae828270456a7"
     url = "https://github.com/alpinelinux/docker-alpine/raw/2f3c3015951938c521e752899a92ecd618e0c05b/x86_64/alpine-minirootfs-3.12.4-x86_64.tar.gz"
 
+[arch]
+git-tree-sha1 = "56e7ce6afb1ef745756d4208fbd43f71d730c644"
+lazy = true
+
+    [[arch.download]]
+    sha256 = "3c52ff78b345e05856535fed534298c05ba7f5b489817e9c30a99744c1c30192"
+    url = "https://github.com/JuliaCI/PkgEval.jl/releases/download/v0.1/arch-devel-20220111.tar.xz"
+
 [debian]
 git-tree-sha1 = "629416ae3d28494fea097fedc57d0fdd748731e3"
 lazy = true

--- a/rootfs/arch.sh
+++ b/rootfs/arch.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -uxe
+
+version="devel"
+date=$(date +%Y%m%d)
+
+rootfs=$(mktemp --directory --tmpdir="/tmp")
+
+# download from https://gitlab.archlinux.org/archlinux/archlinux-docker/-/packages
+# pass as argumnent
+archive=$1
+
+sudo tar -xvf $archive -C $rootfs
+
+sudo chown "$(id -u)":"$(id -g)" -R "$rootfs"
+pushd "$rootfs"
+
+# replace hardlinks with softlinks (working around JuliaIO/Tar.jl#101)
+target_inode=-1
+find . -type f -links +1 -printf "%i %p\n" | sort -nk1 | while read inode path; do
+    if [[ $target_inode != $inode ]]; then
+        target_inode=$inode
+        target_path=$path
+    else
+        ln -sf $target_path $path
+    fi
+done
+
+# Sandbox.jl is picky about directories in the rootfs, so create them
+mkdir proc dev
+
+tar -cJf "/tmp/arch-$version-$date.tar.xz" .
+popd
+rm -rf "$rootfs"

--- a/src/report.jl
+++ b/src/report.jl
@@ -26,6 +26,7 @@ const reasons = Dict(
     :unreachable            => "an unreachable instruction was executed",
     :network                => "networking-related issues were detected",
     :unknown                => "there were unidentified errors",
+    :uncompilable           => "compilation of the package failed",
     # kill
     :time_limit             => "test duration exceeded the time limit",
     :log_limit              => "test log exceeded the size limit",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,16 @@ end
     end
 end
 
+@testset "PackageCompiler" begin
+    results = PkgEval.run([Configuration(julia=julia_version, compiled=true)], ["Example"])
+    if !(julia_spec == "master" || julia_spec == "nightly")
+        @test all(results.status .== :ok)
+        for result in eachrow(results)
+            @test occursin("Testing $(result.name) tests passed", result.log)
+        end
+    end
+end
+
 @testset "reporting" begin
     lts = Configuration(julia=v"1.0.5")
     stable = Configuration(julia=v"1.2.0")


### PR DESCRIPTION
Initial stab at https://github.com/JuliaCI/PkgEval.jl/issues/79. Uses PackageCompiler to generate a custom systemimage that includes the package we're interested in (albeit without any precompilation statements, but I don't think that matters). It then uses that system image to run tests, but in a slightly different container (Arch Linux based) and with a different depot.

TODO:

- [x] Print some statistics on the generated image
- [x] Change the user / home folder.