### PR TITLE
skip PkgEval for OptionalArgChecks.jl

### DIFF
--- a/deps/Registries.toml
+++ b/deps/Registries.toml
@@ -14,6 +14,7 @@ skip = [
     "ClimateMachine", # Requires MPI
     "MPI", # Requires MPI
     "CUDAnative", # Deprecated
+    "OptionalArgChecks", # broken, generates invalid IR
 ]
 retry = [
     "EcologicalNetworks",


### PR DESCRIPTION
This package was really just an experiment and never worked reliably, so it basically just generates noise.

Ref simeonschaub/OptionalArgChecks.jl#24