### PR TITLE
Use a local compilecache, sync after execution.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         arch:
           - x64
         build_spec:
-          - v1.7.0      # release from versions.json
-          - nightly     # special release
-          - master      # directly from Git, likely built by CI
-          - master~500  # directly from Git, unlikely built by CI
+          - v1.7.0                                    # release from versions.json
+          - nightly                                   # special release
+          - master                                    # directly from Git, likely built by CI
+          - 917b11e928612b5352c4e157b38759eb11aa9152  # directly from Git, unlikely built by CI
     env:
       JULIA_DEBUG: PkgEval
       JULIA: ${{ matrix.build_spec }}


### PR DESCRIPTION
I noticed some slowdown after adding a shared compilecache to Nanosoldier, and I'm thinking this may be due to workers running into one another while precompiling packages. So let's try this out: packages are precompiled into a local compilecache (`~/.julia/.../compiled`), and after completion copied into a global cache that's mounted read-only at the system depot (`/usr/local/share/julia`).

@vtjnash Any thoughts? The reason I want to share the compile cache, is that when running under `--bug-report` we otherwise precompile BugReporting.jl's dependencies over and over again. This makes e.g. Example.jl take 30 sec to install/test, whereas it normally only takes 3. Sharing the compilecache gets it down to ~10 sec.