### PR TITLE
Support for customizing the build command + BinaryBuilder removal

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -14,9 +14,9 @@ git-tree-sha1 = "795db6086ddceb415b9dbd8a1f257836d05ac757"
     url = "https://github.com/JuliaCI/PkgEval.jl/releases/download/v0.1/arch-devel-20220628.tar.xz"
 
 [debian]
-git-tree-sha1 = "629416ae3d28494fea097fedc57d0fdd748731e3"
+git-tree-sha1 = "898541a408d0a12a75c271e1a710e1b25b5364b7"
 lazy = true
 
     [[debian.download]]
-    sha256 = "3c3c78a1b15490bfdc29cfd10a72f5f16195ccf64ffc4cdfb445cad387ea5b50"
-    url = "https://github.com/JuliaCI/PkgEval.jl/releases/download/v0.1/debian-buster-20210420.tar.xz"
+    sha256 = "17d97feef816f6c3c7c529723aa0b8f1f0ac62448033ca7384d2078a9b66c803"
+    url = "https://github.com/JuliaCI/PkgEval.jl/releases/download/v0.1/debian-buster-20220818.tar.xz"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Keno Fischer <keno@juliacomputing.com>", "Tim Besard <tim@juliacompu
 version = "0.2.0"
 
 [deps]
-BinaryBuilder = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
@@ -18,7 +17,6 @@ Sandbox = "9307e30f-c43e-9ca7-d17c-c2dc59df670d"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
-BinaryBuilder = "0.4"
 DataFrames = "1.0"
 Downloads = "1.0"
 julia = "1.7"

--- a/rootfs/debian.sh
+++ b/rootfs/debian.sh
@@ -12,7 +12,7 @@ packages+=(curl ca-certificates)
 # essential tools
 packages+=(git unzip)
 # toolchain
-packages+=(build-essential gfortran pkg-config)
+packages+=(build-essential libatomic1 python gfortran perl wget m4 cmake pkg-config curl)
 
 function join_by { local IFS="$1"; shift; echo "$*"; }
 package_list=$(join_by , ${packages[@]})

--- a/rootfs/debian.sh
+++ b/rootfs/debian.sh
@@ -34,17 +34,6 @@ sudo sed '/_apt:/d' -i "$rootfs"/etc/passwd
 sudo chown "$(id -u)":"$(id -g)" -R "$rootfs"
 pushd "$rootfs"
 
-# replace hardlinks with softlinks (working around JuliaIO/Tar.jl#101)
-target_inode=-1
-find . -type f -links +1 -printf "%i %p\n" | sort -nk1 | while read inode path; do
-    if [[ $target_inode != $inode ]]; then
-        target_inode=$inode
-        target_path=$path
-    else
-        ln -sf $target_path $path
-    fi
-done
-
 tar -cJf "/tmp/debian-$version-$date.tar.xz" .
 popd
 rm -rf "$rootfs"

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,6 +4,7 @@ Base.@kwdef struct Configuration
     # Julia properties
     julia::String = "nightly"
     buildflags::Vector{String} = String[]
+    buildcommands::String="make install"
 
     # registry properties
     registry::String = "master"


### PR DESCRIPTION
This PR adds support for customizing the build command, which defaults to `make install`. This makes it possible to do ASAN builds:

```
config = Configuration(julia="master", buildcommands="contrib/asan/build.sh . install")
```

The above however is compatible with a BB-based build environment, where the glibc build of Clang that we download doesn't execute on the musl environment. Instead of fixing that, I decided to replace BB with direct use of the sandbox, as we won't be doing cross-compilation of Julia anyway (which is in compatible with the native execution by PkgEval).