### PR TITLE
Retry packages that fail in one configuration

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -21,15 +21,3 @@ skip = [
     "MPI",                  # MPI
     "BitemporalPostgres",   # POSTGRES
 ]
-retry = [
-    "EcologicalNetworks",
-    "FixedEffectModels",
-    "GLM",
-    "SpatialJackknife",
-    "StatsModels",
-    "UncertainData",
-    "StressTest",
-    "StateSpaceReconstruction",
-    "PolyChaos",
-    "RoME",
-]

--- a/src/PkgEval.jl
+++ b/src/PkgEval.jl
@@ -8,7 +8,6 @@ download_dir = ""
 storage_dir = ""
 
 skip_list = String[]
-retry_list = String[]
 
 include("types.jl")
 include("registry.jl")
@@ -29,7 +28,6 @@ function __init__()
     # read Packages.toml
     packages = TOML.parsefile(joinpath(dirname(@__DIR__), "Packages.toml"))
     global skip_list = get(packages, "skip", String[])
-    global retry_list = get(packages, "retry", String[])
 end
 
 end # module

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -767,18 +767,9 @@ function _evaluate(jobs; ninstances::Integer=Sys.CPU_THREADS)
                             continue
                         end
 
-                        # perform an initial run
+                        # test the package
                         config′ = Configuration(config; cpus=[i-1])
                         pkg_version, status, reason, log = evaluate_test(config′, pkg)
-
-                        # certain packages are known to have flaky tests; retry them
-                        for j in 1:pkg.retries
-                            if status == :fail && reason == :test_failures
-                                times[i] = now()
-                                pkg_version, status, reason, log =
-                                    evaluate_test(config′, pkg)
-                            end
-                        end
 
                         duration = (now()-times[i]) / Millisecond(1000)
                         push!(result, [config_name, pkg.name, pkg_version,

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -1,9 +1,9 @@
 """
-    registry_packages(config::Configuration; [retries::Integer=2])::Vector{Package}
+    registry_packages(config::Configuration)::Vector{Package}
 
 Read all packages from a registry and return them as a vector of Package structs.
 """
-function registry_packages(config::Configuration; retries::Integer=2)
+function registry_packages(config::Configuration)
     packages = Package[]
 
     # NOTE: we handle Registry check-outs ourselves, so can't use Pkg APIs
@@ -13,9 +13,7 @@ function registry_packages(config::Configuration; retries::Integer=2)
         path = joinpath(registry, string(char), entry)
         isdir(path) || continue
         # TODO: read package compat info so that we can avoid testing uninstallable packages
-        push!(packages,
-              Package(name=entry,
-                      retries=(entry in retry_list ? retries : 0)))
+        push!(packages, Package(name=entry))
     end
     return packages
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -116,8 +116,6 @@ Base.@kwdef struct Package
     version::Union{Nothing,VersionNumber} = nothing
     url::Union{Nothing,String} = nothing
     rev::Union{Nothing,String} = nothing
-
-    retries::Int = 0
 end
 
 # convert a Package to a tuple that's Pkg.add'able


### PR DESCRIPTION
Instead of maintaining a list of packages to retry, this PR makes it so that PkgEval retries all packages that failed in one or more (but not all) configurations. I'm not entirely sure this is what we want (it might blow up test time if it ends up retrying packages that hit the time limit), and whether we want this by default or not, but we can give this a try and see how it goes.

Fixes https://github.com/JuliaCI/PkgEval.jl/issues/122