### PR TITLE
Work around packages mutating their own files

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -337,6 +337,7 @@ function evaluate_test(config::Configuration, pkg::Package; kwargs...)
             versioninfo()
 
             using Pkg
+            using Base: UUID
             package_spec = eval(Meta.parse(ARGS[1]))
 
             println("\nCompleted after $(elapsed(t0))")
@@ -543,6 +544,7 @@ function evaluate_compiled_test(config::Configuration, pkg::Package; kwargs...)
             println()
 
             using Pkg
+            using Base: UUID
             package_spec = eval(Meta.parse(ARGS[1]))
 
             println("Installing PackageCompiler...")

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -294,19 +294,19 @@ function remove_uncacheable_packages(registry, packages)
                 ispath(path) || continue
                 remove = false
 
-                # we cannot cache packages that have a build script,
-                # because that would result in the build script not being run.
                 if ispath(joinpath(path, "deps", "build.jl"))
+                    # we cannot cache packages that have a build script,
+                    # because that would result in the build script not being run.
+                    remove = true
+                elseif Base.SHA1(Pkg.GitTools.tree_hash(path)) != tree_hash
+                    # the contents of the package should match what's in the registry,
+                    # so that we don't cache broken checkouts or other weirdness.
                     remove = true
                 end
 
-                # the contents of the package should match exactly what is in the registry,
-                # so that we don't cache broken checkouts or other weirdness.
-                if Base.SHA1(Pkg.GitTools.tree_hash(path)) != tree_hash
-                    remove = true
+                if remove
+                    rm(path; recursive=true)
                 end
-
-                remove && rm(path; recursive=true)
             end
         end
     end

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -355,6 +355,18 @@ function evaluate_test(config::Configuration, pkg::Package; kwargs...)
 
                 Pkg.add(; package_spec...)
 
+                # make sure that the package we're testing resides in the primary depot.
+                # otherwise it may not be writable, which many packages (sadly) require.
+                package_info = Pkg.dependencies()[package_spec.uuid]
+                if !startswith(package_info.source, DEPOT_PATH[1])
+                    slug = basename(package_info.source)
+                    new_source = joinpath(DEPOT_PATH[1], "packages", package_info.name, slug)
+                    mkpath(dirname(new_source))
+                    cp(package_info.source, new_source)
+                    package_info = Pkg.dependencies()[package_spec.uuid]
+                    @assert startswith(package_info.source, DEPOT_PATH[1])
+                end
+
                 println("\nCompleted after $(elapsed(t1))")
             end
 

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -270,9 +270,11 @@ function verify_artifacts(artifacts)
         tree_hash = tryparse(Base.SHA1, entry)
         if tree_hash === nothing
             # remove directory entries that do not look like a valid artifact
+            @warn "An invalid artifact was found: $entry"
             remove = true
         elseif tree_hash != Base.SHA1(Pkg.GitTools.tree_hash(path))
             # remove corrupt artifacts
+            @warn "A broken artifact was found: $entry"
             remove = true
         end
 

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -6,14 +6,11 @@ Read all packages from a registry and return them as a vector of Package structs
 function registry_packages(config::Configuration)
     packages = Package[]
 
-    # NOTE: we handle Registry check-outs ourselves, so can't use Pkg APIs
-    #       (since they do not accept an argument to point to a custom Registry)
     registry = get_registry(config)
-    for char in 'A':'Z', entry in readdir(joinpath(registry, string(char)))
-        path = joinpath(registry, string(char), entry)
-        isdir(path) || continue
+    registry_instance = Pkg.Registry.RegistryInstance(registry)
+    for (_, pkg) in registry_instance
         # TODO: read package compat info so that we can avoid testing uninstallable packages
-        push!(packages, Package(name=entry))
+        push!(packages, Package(name=pkg.name, uuid=pkg.uuid))
     end
     return packages
 end


### PR DESCRIPTION
Turns out lots of packages do this, which breaks the way we cache packages in a layered, read-only depot. So as a workaround, copy the package we're testing from the global, read-only depot dir into the local, mutable one.