### PR TITLE
TO DEBUG: changes that cause a significant regression [DO NOT MERGE]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,25 +6,29 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.build_spec }}
+    name: Julia ${{ matrix.version }} - Running ${{ matrix.test_julia }} ${{ matrix.test_buildflags }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.7'
+          - '1.8'
         os:
           - ubuntu-latest
         arch:
           - x64
-        build_spec:
-          - v1.7.0                                    # release from versions.json
-          - nightly                                   # special release
-          - master                                    # directly from Git, likely built by CI
-          - 917b11e928612b5352c4e157b38759eb11aa9152  # directly from Git, unlikely built by CI
+        test_julia:
+          - "v1.8.0"              # release from versions.json
+          - "nightly"             # special release
+          - "master"              # directly from Git
+        include:
+          - test_julia: "master"  # force a build
+            test_buildflags: "JULIA_CPU_TARGET=native"
     env:
       JULIA_DEBUG: PkgEval
-      JULIA: ${{ matrix.build_spec }}
+      JULIA: ${{ matrix.test_julia }}
+      BUILDFLAGS: ${{ matrix.test_buildflags }}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -20,3 +20,11 @@ lazy = true
     [[debian.download]]
     sha256 = "072392d8635847de70665af512551038b04baca99b38e271d0eef1ea36d2833a"
     url = "https://github.com/JuliaCI/PkgEval.jl/releases/download/v0.1/debian-bullseye-20220818.tar.xz"
+
+[package_linux]
+git-tree-sha1 = "1f829834cb7dfbfff7068892af39608ff6112c28"
+lazy = true
+
+    [[package_linux.download]]
+    sha256 = "39db1a3e1ef8b624daea4e7f3f0355e249043de960e16a1988cb96ed9ef725fc"
+    url = "https://github.com/JuliaCI/rootfs-images/releases/download/v5.30/package_linux.x86_64.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -22,9 +22,9 @@ lazy = true
     url = "https://github.com/JuliaCI/PkgEval.jl/releases/download/v0.1/debian-bullseye-20220818.tar.xz"
 
 [package_linux]
-git-tree-sha1 = "1f829834cb7dfbfff7068892af39608ff6112c28"
+git-tree-sha1 = "104eaa2e0f648fd5de41697329b544a92f3edabf"
 lazy = true
 
     [[package_linux.download]]
-    sha256 = "39db1a3e1ef8b624daea4e7f3f0355e249043de960e16a1988cb96ed9ef725fc"
-    url = "https://github.com/JuliaCI/rootfs-images/releases/download/v5.30/package_linux.x86_64.tar.gz"
+    sha256 = "20b8706720ae9d1471abc209c704570b7a7596c7d953050ac1f27094fd31bbf2"
+    url = "https://github.com/JuliaCI/rootfs-images/releases/download/v5.31/package_linux.x86_64.tar.gz"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ shell:
 ```julia
 julia> using PkgEval
 
-julia> config = Configuration(; julia="1.7");
+julia> config = Configuration()
+PkgEval configuration(
+  ...
+)
 
 julia> PkgEval.sandboxed_julia(config)
 
@@ -58,11 +61,20 @@ julia> PkgEval.sandboxed_julia(config)
   (_)     | (_) (_)    |
    _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
   | | | | | | |/ _` |  |
-  | | |_| | | | (_| |  |  Version 1.7.0 (2021-11-30)
- _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
+  | | |_| | | | (_| |  |  Version 1.9.0-DEV.1163 (2022-08-21)
+ _/ |\__'_|_|_|\__'_|  |  Commit 696f7d3dfe1 (1 day old master)
 |__/                   |
 
 julia> # we're in the PkgEval sandbox here
 ```
 
-Now you can install, load and test your package.
+Now you can install, load and test your package. This will, by default, use a nightly build
+of Julia. If you want PkgEval.jl to compile Julia, e.g. to test a specific version, create
+a Configuration instance as such:
+
+```julia
+julia> config = Configuration(julia="master",
+                              buildflags=["JULIA_CPU_TARGET=native", "JULIA_PRECOMPILE=0"])
+
+# NOTE: buildflags are specified to speed-up the build
+```

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -391,7 +391,8 @@ function evaluate_test(config::Configuration, pkg::Package; kwargs...)
                 occursin("Could not resolve host", log) ||
                 occursin("Resolving timed out after", log) ||
                 occursin("Could not download", log) ||
-                occursin(r"Error: HTTP/\d \d+", log)
+                occursin(r"Error: HTTP/\d \d+", log) ||
+                occursin("Temporary failure in name resolution", log)
             :network
         elseif occursin("ERROR: LoadError: syntax", log)
             :syntax

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -274,7 +274,6 @@ function clean_packages(registry, packages)
                          Base.version_slug(pkg.uuid, tree_hash, 4))
                 path = joinpath(packages, pkg.name, slug)
                 if ispath(path) && Base.SHA1(Pkg.GitTools.tree_hash(path)) != tree_hash
-                    println("\n\n\nremoving dirty package: $path\n\n\n")
                     rm(path; recursive=true)
                 end
             end

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -520,7 +520,7 @@ function evaluate_test(config::Configuration, pkg::Package; kwargs...)
             unixtime = round(Int, datetime2unix(now()))
             trace_unique_name = "$(pkg.name)-$(unixtime).tar.zst"
             if isfile(trace_file)
-                run(`$(s5cmd) --log error cp -acl public-read $trace_file s3://$(bucket)/$(trace_unique_name)`)
+                run(`$(s5cmd()) --log error cp -acl public-read $trace_file s3://$(bucket)/$(trace_unique_name)`)
                 log *= "Uploaded rr trace to https://s3.amazonaws.com/$(bucket)/$(trace_unique_name)"
             else
                 log *= "Testing did not produce an rr trace."

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -624,6 +624,9 @@ function evaluate(configs::Dict{String,Configuration}, packages::Vector{Package}
                 for row in eachrow(failures)
                     push!(retry_jobs, (row.configuration, configs[row.configuration], package))
                 end
+            else
+                # don't lose track of this failure
+                append!(other_results, failures)
             end
         end
 

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -335,7 +335,7 @@ function evaluate_test(config::Configuration, pkg::Package; kwargs...)
             versioninfo()
 
             using Pkg
-            using Base: UUID
+            using Base: UUID, PkgId
             package_spec = eval(Meta.parse(ARGS[1]))
 
             bugreporting = get(ENV, "PKGEVAL_RR", "false") == "true" &&
@@ -346,10 +346,8 @@ function evaluate_test(config::Configuration, pkg::Package; kwargs...)
 
             # check if we even need to install the package
             # (it might be available in the system image already)
-            try
-                # XXX: use a Base API, by UUID?
-                eval(:(using $(Symbol(package_spec.name))))
-            catch
+            package_id = PkgId(package_spec.uuid, package_spec.name)
+            if !Base.root_module_exists(package_id)
                 print("\n\n", '#'^80, "\n# Installation\n#\n\n")
                 println("Started at ", now(UTC), "\n")
                 t1 = time()

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -43,7 +43,7 @@ const compiled_cache = Dict()
 function get_compilecache(config::Configuration)
     lock(compiled_lock) do
         key = (config.julia, config.buildflags,
-               config.distro, config.uid, config.user, config.gid, config.group, config.home)
+               config.rootfs, config.uid, config.user, config.gid, config.group, config.home)
         dir = get(compiled_cache, key, nothing)
         if dir === nothing || !isdir(dir)
             compiled_cache[key] = mktempdir()
@@ -520,7 +520,7 @@ function evaluate_compiled_test(config::Configuration, pkg::Package; kwargs...)
         rr = false,
         # discover package relocatability issues by compiling in a different environment
         julia_install_dir="/usr/local/julia",
-        distro="arch",
+        rootfs="arch",
         user="user",
         group="group",
         home="/home/user",

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -848,22 +848,8 @@ function _evaluate(jobs; ninstances::Integer=Sys.CPU_THREADS)
                        duration = Float64[],
                        log = Union{Missing,String}[])
 
-    # Printer
-    @async begin
-        try
-            while (!isempty(jobs) || !all(==(nothing), running)) && !done
-                update_output()
-            end
-            stop_work()
-        catch e
-            stop_work()
-            isa(e, InterruptException) || rethrow(e)
-        end
-    end
-
-    # Workers
-    # TODO: we don't want to do this for both. but rather one of the builds is compiled, the other not...
     try @sync begin
+        # Workers
         for i = 1:ninstances
             push!(all_workers, @async begin
                 try
@@ -894,15 +880,30 @@ function _evaluate(jobs; ninstances::Integer=Sys.CPU_THREADS)
                                        status, reason, duration, log])
                         running[i] = nothing
                     end
-                catch e
+                catch err
                     stop_work()
-                    isa(e, InterruptException) || rethrow(e)
+                    isa(err, InterruptException) || rethrow(err)
                 end
             end)
         end
+
+        # Printer
+        @async begin
+            try
+                while (!isempty(jobs) || !all(==(nothing), running)) && !done
+                    update_output()
+                end
+            catch err
+                isa(err, InterruptException) || rethrow(err)
+            finally
+                stop_work()
+            end
+        end
     end
-    catch e
-        isa(e, InterruptException) || rethrow(e)
+    catch err
+        # XXX: why doesn't it suffice just catching the the InterruptException
+        #      (unwrapped from CompositeException) here?
+        isa(err, InterruptException) || rethrow(err)
     finally
         stop_work()
         println()

--- a/src/julia.jl
+++ b/src/julia.jl
@@ -156,7 +156,7 @@ function build_julia(_repo_path::String, config::Configuration)
 
     # build and install Julia
     install_dir = mktempdir()
-    build_config = Configuration(; xvfb=false)
+    build_config = Configuration(; rootfs="package_linux", xvfb=false)
     mounts = Dict(
         "/source:rw"    => repo_path,
         "/install:rw"   => install_dir

--- a/src/rootfs.jl
+++ b/src/rootfs.jl
@@ -3,7 +3,7 @@ using LazyArtifacts: @artifact_str
 lazy_artifact(x) = @artifact_str(x)
 
 function _create_rootfs(config::Configuration)
-    base = lazy_artifact(config.distro)
+    base = lazy_artifact(config.rootfs)
 
     # a bare rootfs isn't usable out-of-the-box
     derived = mktempdir()
@@ -34,7 +34,7 @@ const rootfs_lock = ReentrantLock()
 const rootfs_cache = Dict()
 function create_rootfs(config::Configuration)
     lock(rootfs_lock) do
-        key = (config.distro, config.uid, config.user, config.gid, config.group, config.home)
+        key = (config.rootfs, config.uid, config.user, config.gid, config.group, config.home)
         dir = get(rootfs_cache, key, nothing)
         if dir === nothing || !isdir(dir)
             rootfs_cache[key] = _create_rootfs(config)

--- a/src/types.jl
+++ b/src/types.jl
@@ -38,7 +38,7 @@ Base.@kwdef struct Configuration
     registry::Setting{String} = Default("master")
 
     # rootfs properties
-    distro::Setting{String} = Default("debian")
+    rootfs::Setting{String} = Default("debian")
     uid::Setting{Int} = Default(1000)
     user::Setting{String} = Default("pkgeval")
     gid::Setting{Int} = Default(1000)
@@ -81,7 +81,7 @@ function Base.show(io::IO, cfg::Configuration)
     println(io)
 
     println(io, "  # Rootfs properties")
-    show_setting.(["distro", "uid", "user", "gid", "group", "home"])
+    show_setting.(["rootfs", "uid", "user", "gid", "group", "home"])
     println(io)
 
     println(io, "  # Execution properties")


### PR DESCRIPTION
The changes in this PR, which all passed CI, turned out to cause a significant regression when deployed on amdci. To debug this, I've reverted master to the last known-good state (bcb604a56be904d2d2cb91574a8673325a34cfc0) and split the relevant changes into separate PRs. Only the stdlib changes are too hard to split apart, hence this PR so that nothing gets lost.