### PR TITLE
Interleave retries

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -605,7 +605,7 @@ function evaluate_compiled_test(config::Configuration, pkg::Package; kwargs...)
     if status !== :ok
         rm(sysimage_dir; recursive=true)
         rm(project_dir; recursive=true)
-        return missing, status, reason, log
+        return missing, status, reason, 0.0, log
     end
 
     # run the tests in the regular environment


### PR DESCRIPTION
Currently we're starting a whole new evaluation in order to retry certain failed packages, which is wasteful because each evaluation often ends with a long tail of packages that take a very long time (i.e., not running in parallel with many other packages). So instead, interleave the retries with the main evaluation in order to optimize parallel execution.

WIP because I want to refactor some things in light of this.