### PR TITLE
Retry packages in a pristine environment.

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -275,15 +275,17 @@ function evaluate_script(config::Configuration, script::String, args=``;
 end
 
 """
-    evaluate_test(config::Configuration, pkg; kwargs...)
+    evaluate_test(config::Configuration, pkg; pristine=false, kwargs...)
 
 Run the unit tests for a single package `pkg` inside of a sandbox according to `config`.
+The `pristine` argument determines whether the package is installed in a pristine
+environment, i.e., without using global caches for packages and artifacts.
 
 Refer to `evaluate_script`[@ref] for more possible `keyword arguments.
 """
-function evaluate_test(config::Configuration, pkg::Package; kwargs...)
+function evaluate_test(config::Configuration, pkg::Package; pristine::Bool=false, kwargs...)
     if config.compiled
-        return evaluate_compiled_test(config, pkg; kwargs...)
+        return evaluate_compiled_test(config, pkg; pristine, kwargs...)
     end
 
     script = raw"""
@@ -373,16 +375,18 @@ function evaluate_test(config::Configuration, pkg::Package; kwargs...)
         args = `--depwarn=error $args`
     end
 
-    packages = joinpath(storage_dir, "packages")
-    artifacts = joinpath(storage_dir, "artifacts")
-    mounts = Dict{String,String}(
-        joinpath(config.home, ".julia", "packages")*":rw"   => packages,
-        joinpath(config.home, ".julia", "artifacts")*":rw"  => artifacts
+    mounts = Dict{String,String}()
+    env = Dict{String,String}()
+
+    if !pristine
         # NOTE: the packages and artifacts directories are mutable, so they can break.
         #       hence we only mount them here, and not in `sandboxed_julia`, because
         #       we know we'll have validated the caches before entering here.
-    )
-    env = Dict{String,String}()
+        packages = joinpath(storage_dir, "packages")
+        artifacts = joinpath(storage_dir, "artifacts")
+        mounts[joinpath(config.home, ".julia", "packages")*":rw"] = packages
+        mounts[joinpath(config.home, ".julia", "artifacts")*":rw"] = artifacts
+    end
 
     status, reason, log, elapsed = if config.rr
         trace_dir = mktempdir()
@@ -525,7 +529,8 @@ contains this package and its dependencies.
 To find incompatibilities, the compilation happens on an Ubuntu-based runner, while testing
 is performed in an Arch Linux container.
 """
-function evaluate_compiled_test(config::Configuration, pkg::Package; kwargs...)
+function evaluate_compiled_test(config::Configuration, pkg::Package;
+                                pristine::Bool=false, kwargs...)
     script = raw"""
         begin
             using Dates
@@ -632,7 +637,7 @@ function evaluate_compiled_test(config::Configuration, pkg::Package; kwargs...)
         julia_args = `$(config.julia_args) --project=$project_path --sysimage $sysimage_path`,
     )
     version, status, reason, duration, test_log =
-        evaluate_test(test_config, pkg; mounts, kwargs...)
+        evaluate_test(test_config, pkg; mounts, pristine, kwargs...)
 
     rm(sysimage_dir; recursive=true)
     rm(project_dir; recursive=true)
@@ -778,7 +783,7 @@ function evaluate(configs::Dict{String,Configuration}, packages::Vector{Package}
     # determine the jobs to run
     jobs = Any[]
     for (config_name, config) in configs, package in packages
-        push!(jobs, (config_name, config, package))
+        push!(jobs, (config_name, config, package, false))
     end
     ## use a random test order to (hopefully) get a more reasonable ETA
     shuffle!(jobs)
@@ -837,14 +842,14 @@ function evaluate(configs::Dict{String,Configuration}, packages::Vector{Package}
             push!(all_workers, @async begin
                 try
                     while !isempty(jobs) && !done
-                        config_name, config, pkg = pop!(jobs)
+                        config_name, config, pkg, pristine = pop!(jobs)
                         times[i] = now()
                         running[i] = (config_name, pkg)
 
                         # test the package
                         config′ = Configuration(config; cpus=[i-1])
                         pkg_version, status, reason, duration, log =
-                            evaluate_test(config′, pkg)
+                            evaluate_test(config′, pkg; pristine)
 
                         push!(result, [config_name, pkg.name, pkg_version,
                                        status, reason, duration, log])
@@ -861,7 +866,8 @@ function evaluate(configs::Dict{String,Configuration}, packages::Vector{Package}
                             end
                             if length(configs) == 1 || nrow(failures) != length(configs)
                                 for row in eachrow(failures)
-                                    push!(jobs, (row.configuration, configs[row.configuration], pkg))
+                                    # retry the failed job in a pristine environment
+                                    push!(jobs, (row.configuration, configs[row.configuration], pkg, true))
                                 end
 
                                 # XXX: this needs a proper API in ProgressMeter.jl

--- a/src/types.jl
+++ b/src/types.jl
@@ -167,5 +167,6 @@ end
 struct Job
     config::Configuration
     package::Package
-    cache::Bool
+
+    use_cache::Bool
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -144,3 +144,13 @@ function package_spec_tuple(pkg::Package)
     end
     spec
 end
+
+
+## test job
+
+struct Job
+    config::Configuration
+    config_name::String
+    package::Package
+    cache::Bool
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,8 +149,8 @@ end
 end
 
 @testset "PackageCompiler" begin
-    results = evaluate(Dict("regular"  => Configuration(; config_kwargs...),
-                            "compiled" => Configuration(; config_kwargs..., compiled=true)),
+    results = evaluate([Configuration(; name="regular", config_kwargs...),
+                        Configuration(; name="compiled", compiled=true, config_kwargs...)],
                        [Package(; name="Example")])
     @test size(results, 1) == 2
     for result in eachrow(results)


### PR DESCRIPTION
Cachine packages with a `deps/build` folder is invalid (the build step doesn't re-run if we install the package the next time), so if we retry we should do so in a pristine environment that doesn't use cached packages/artifacts.