### PR TITLE
Set JULIA_PRECOMPILE=0 to speed-up CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - "master"              # directly from Git, force a build (see below)
         include:
           - test_julia: "master"
-            test_buildflags: "JULIA_CPU_TARGET=native"
+            test_buildflags: "JULIA_CPU_TARGET=native JULIA_PRECOMPILE=0"
     env:
       JULIA_DEBUG: PkgEval
       JULIA: ${{ matrix.test_julia }}

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -388,23 +388,26 @@ function evaluate_test(config::Configuration, pkg::Package; use_cache::Bool=true
     # log the status and determine a more accurate reason from the log
     @assert status in [:ok, :fail, :kill]
     ## crashes so bad we override the status
-    if occursin("GC error (probable corruption)", log)
-        status = :crash
-        reason = :gc_corruption
-    elseif occursin(r"signal \(.+\): Segmentation fault", log)
-        status = :crash
-        reason = :segfault
-    elseif occursin(r"signal \(.+\): Abort", log)
-        status = :crash
-        reason = :abort
-    elseif occursin("Unreachable reached", log)
-        status = :crash
-        reason = :unreachable
-    elseif occursin("Internal error: encountered unexpected error in runtime", log) ||
-           occursin("Internal error: stack overflow in type inference", log) ||
-           occursin("Internal error: encountered unexpected error during compilation", log)
-        status = :crash
-        reason = :internal
+    if status !== :kill
+        # ... but not in the case of a kill, as a badly-timed signal may cause crashes
+        if occursin("GC error (probable corruption)", log)
+            status = :crash
+            reason = :gc_corruption
+        elseif occursin(r"signal \(.+\): Segmentation fault", log)
+            status = :crash
+            reason = :segfault
+        elseif occursin(r"signal \(.+\): Abort", log)
+            status = :crash
+            reason = :abort
+        elseif occursin("Unreachable reached", log)
+            status = :crash
+            reason = :unreachable
+        elseif occursin("Internal error: encountered unexpected error in runtime", log) ||
+            occursin("Internal error: stack overflow in type inference", log) ||
+            occursin("Internal error: encountered unexpected error during compilation", log)
+            status = :crash
+            reason = :internal
+        end
     end
     ## others we only look for when the test failed
     if status === :fail

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,7 +122,7 @@ end
 
 @testset "time and output limits" begin
     # timeouts
-    let results = evaluate([Configuration(config; time_limit=0.1)],
+    let results = evaluate([Configuration(config; time_limit=1.)],
                            [Package(; name="Example")])
         @test size(results, 1) == 1
         @test results[1, :status] == :kill && results[1, :reason] == :time_limit


### PR DESCRIPTION
I had included this in the Buildkite PR, but it seems to cause segfaults, so let's investigate.