### PR TITLE
Test embedded standard libraries

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -552,6 +552,7 @@ is performed in an Arch Linux container.
 """
 function evaluate_compiled_test(config::Configuration, pkg::Package;
                                 use_cache::Bool=true, kwargs...)
+    @assert !pkg.stdlib
     script = raw"""
         begin
             using Dates

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -618,7 +618,6 @@ function evaluate_compiled_test(config::Configuration, pkg::Package;
     )
 
     compile_config = Configuration(config;
-        julia_args = `$(config.julia_args)`,
         time_limit = config.compile_time_limit,
         # don't record the compilation, only the test execution
         rr = false,

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -287,9 +287,11 @@ function evaluate_test(config::Configuration, pkg::Package; use_cache::Bool=true
             println("\n$(package_spec.name) is a standard library in this Julia build.")
 
             # we currently only support testing the embedded version of stdlib packages
-            @assert !haskey(package_spec, :version)
-            @assert !haskey(package_spec, :url)
-            @assert !haskey(package_spec, :ref)
+            if haskey(package_spec, :version) ||
+               haskey(package_spec, :url) ||
+               haskey(package_spec, :ref)
+                error("Packages that are standard libraries can only be tested using the embedded version.")
+            end
         end
 
         println("\nSet-up completed after $(elapsed(t0))")
@@ -574,7 +576,7 @@ function evaluate_compiled_test(config::Configuration, pkg::Package;
             package_spec = eval(Meta.parse(ARGS[1]))
 
             if haskey(Pkg.Types.stdlibs(), package_spec.uuid)
-                error("Compiling stdlibs does not make sense.")
+                error("Packages that are standard libraries cannot be compiled again.")
             end
 
             println("Installing PackageCompiler...")

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -18,7 +18,7 @@ Determine the packages that we can test for a given configuration.
 """
 function get_packages(config::Configuration)
     lock(packages_lock) do
-        key = config.julia
+        key = (config.julia, config.compiled)
         val = get(packages_cache, key, nothing)
         if val === nothing
             packages_cache[key] = _get_packages(config)
@@ -57,6 +57,11 @@ function _get_packages(config::Configuration)
         packages[name] = Package(; name, uuid=UUID(uuid), stdlib=true)
     end
     success(proc) || error("Failed to list standard libraries")
+
+    # it doesn't make sense to test stdlibs in compiled mode
+    if config.compiled
+        filter!(item->!item.second.stdlib, packages)
+    end
 
     return packages
 end

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -1,20 +1,3 @@
-"""
-    registry_packages(config::Configuration)::Vector{Package}
-
-Read all packages from a registry and return them as a vector of Package structs.
-"""
-function registry_packages(config::Configuration)
-    packages = Package[]
-
-    registry = get_registry(config)
-    registry_instance = Pkg.Registry.RegistryInstance(registry)
-    for (_, pkg) in registry_instance
-        # TODO: read package compat info so that we can avoid testing uninstallable packages
-        push!(packages, Package(name=pkg.name, uuid=pkg.uuid))
-    end
-    return packages
-end
-
 const registry_lock = ReentrantLock()
 const registry_cache = Dict()
 function get_registry(config::Configuration)
@@ -26,4 +9,35 @@ function get_registry(config::Configuration)
         end
         return registry_cache[config.registry]
     end
+end
+
+"""
+    packages(config::Configuration)::Dict{String,Package}
+
+Determine the packages that we can test for a given configuration.
+"""
+function get_packages(config::Configuration)
+    lock(packages_lock) do
+        key = config.julia
+        val = get(packages_cache, key, nothing)
+        if val === nothing
+            packages_cache[key] = _get_packages(config)
+        end
+        return packages_cache[key]
+    end
+end
+const packages_lock = ReentrantLock()
+const packages_cache = Dict()
+
+function _get_packages(config::Configuration)
+    packages = Dict{String,Package}()
+
+    registry = get_registry(config)
+    registry_instance = Pkg.Registry.RegistryInstance(registry)
+    for (_, pkg) in registry_instance
+        # TODO: read package compat info so that we can avoid testing uninstallable packages
+        packages[pkg.name] = Package(; pkg.name, pkg.uuid)
+    end
+
+    return packages
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -148,8 +148,6 @@ Base.@kwdef struct Package
     version::Union{Nothing,VersionNumber} = nothing
     url::Union{Nothing,String} = nothing
     rev::Union{Nothing,String} = nothing
-
-    stdlib::Bool = false
 end
 
 # copy constructor that allows overriding specific fields


### PR DESCRIPTION
Discover stdlibs by calling `Pkg.Types.stdlibs()` and just `Pkg.add`/`Pkg.test` those.

To be squash-merged.