### PR TITLE
Treat more packages as 'skipped'

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -822,13 +822,12 @@ function evaluate(configs::Vector{Configuration}, packages::Vector{Package}=Pack
     # pre-filter the jobs for packages we'll skip to get a better ETA
     skips = similar(result)
     jobs = filter(jobs) do job
-        if job.package.name in skip_list
+        if endswith(job.package.name, "_jll")
+            # JLLs we ignore completely; it's not useful to include them in the skip count
+            return false
+        elseif job.package.name in skip_list
             push!(skips, [job.config.name, job.package.name, missing,
                           :skip, :explicit, 0, missing])
-            return false
-        elseif endswith(job.package.name, "_jll")
-            push!(skips, [job.config.name, job.package.name, missing,
-                          :skip, :jll, 0, missing])
             return false
         else
             return true

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -351,8 +351,9 @@ function evaluate_test(config::Configuration, pkg::Package; use_cache::Bool=true
             end
 
             println("\nTesting completed after $(elapsed(t1))")
-        catch err
+        catch
             println("\nTesting failed after $(elapsed(t1))\n")
+            rethrow()
         finally
             write("/output/duration", repr(t1-t0))
         end""" * "\nend"


### PR DESCRIPTION
If a package isn't installable, or doesn't have tests, we shouldn't mark it as `fail` but as `skip`.