### PR TITLE
Retry skipped jobs.

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -891,7 +891,7 @@ function evaluate(configs::Vector{Configuration}, packages::Vector{Package}=Pack
                             # NOTE: this check also prevents retrying multiple times
 
                             failures = filter(package_results) do row
-                                row.status in [:fail, :kill, :crash]
+                                row.status !== :ok
                             end
                             if length(configs) == 1 || nrow(failures) != length(configs)
                                 for row in eachrow(failures)


### PR DESCRIPTION
Now that we label uninstallable packages as skip, which may happen due to package store corruption (e.g. in the case of Conda), we should retry these.

This should fix the couple of fail/skip issues we've been seeing on recent PkgEval reports.