### PR TITLE
Improve test kill & crash detection

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -228,6 +228,12 @@ function evaluate_script(config::Configuration, script::String, args=``;
     if status === nothing
         if success(proc)
             status = :ok
+        elseif proc.exitcode == 134 # SIGABRT
+            status = :crash
+            reason = :abort
+        elseif proc.exitcode == 139 # SIGSEGV
+            status = :crash
+            reason = :segfault
         else
             status = :fail
         end


### PR DESCRIPTION
We shouldn't bother sending SIGINT -- systemd goes directly to SIGTERM, and Julia doesn't handle SIGINT well anyway.

We can also try and detect SIGSEGV and SIGABRT from the exit code (128 + SIGNUM) instead of only relying on the logs, for the unlikely case where Julia's signal handlers aren't working. This will matter more for SIGKILL detection, where we don't have such a handler.