### PR TITLE
Improve script include and color handling

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -102,7 +102,7 @@ function evaluate_script(config::Configuration, script::String, args=``;
 
     input = Pipe()
     output = Pipe()
-    proc = sandboxed_julia(config, `--eval 'eval(Meta.parse(read(stdin,String)))' $args`;
+    proc = sandboxed_julia(config, `-e 'include_string(Main, read(stdin,String))' $args`;
                            wait=false, stdout=output, stderr=output, stdin=input,
                            env, mounts, kwargs...)
     close(output.in)

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -102,9 +102,9 @@ function evaluate_script(config::Configuration, script::String, args=``;
 
     input = Pipe()
     output = Pipe()
-    proc = sandboxed_julia(config, `-e 'include_string(Main, read(stdin,String))' $args`;
-                           wait=false, stdout=output, stderr=output, stdin=input,
-                           env, mounts, kwargs...)
+    args = `-e 'include_string(Main, read(stdin,String))' --color=no $args`
+    proc = sandboxed_julia(config, args; stdout=output, stderr=output, stdin=input,
+                           wait=false, env, mounts, kwargs...)
     close(output.in)
 
     # pass the script over standard input to avoid exceeding max command line size,

--- a/src/sandbox.jl
+++ b/src/sandbox.jl
@@ -173,8 +173,5 @@ function setup_julia_sandbox(config::Configuration, args=``;
 end
 
 function sandboxed_julia(config::Configuration, args=``; stdout=stdout, kwargs...)
-    if stdout != stdout
-        args = `--color=no $args`
-    end
     run_sandbox(config, setup_julia_sandbox, args; stdout, kwargs...)
 end


### PR DESCRIPTION
`include_string` gives slightly better stack traces, and is what 1.8 uses when you pass `-` (i.e. read from STDIN).