### PR TITLE
Generalize the skip mechanism to a configurable blacklist.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,14 @@ end
     end
 end
 
+@testset "blacklist" begin
+    let results = evaluate([config], [Package(; name="Example")];
+                           validate=false, retry=false, blacklist=["Example"])
+        @test size(results, 1) == 1
+        @test results[1, :status] == :skip && results[1, :reason] == :blacklist
+    end
+end
+
 @testset "complex packages" begin
     # some more complicate packages that are all expected to pass tests
     package_names = ["TimerOutputs", "Crayons", "Example", "Gtk"]


### PR DESCRIPTION
The goal is to have Nanosoldier.jl provide an additional blacklist, generated here: https://github.com/JuliaCI/NanosoldierReports/commit/54e61b9e1731eff14941add58cb18606817f3df8.