### PR TITLE
Don't precompile packages during Pkg.add.

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -312,7 +312,10 @@ function evaluate_test(config::Configuration, pkg::Package; use_cache::Bool=true
 
         t0 = cpu_time()
         try
-            Pkg.add(; package_spec...)
+            # disable precompilation to avoid precompiling with the wrong options
+            withenv("JULIA_PKG_PRECOMPILE_AUTO" => false) do
+                Pkg.add(; package_spec...)
+            end
 
             println("\nInstallation completed after $(elapsed(t0))")
             write("/output/installed", repr(true))
@@ -593,7 +596,11 @@ function evaluate_compiled_test(config::Configuration, pkg::Package;
         Pkg.activate(project)
 
         println("\nInstalling $(package_spec.name)...")
-        Pkg.add(; package_spec...)
+
+        # disable precompilation to avoid precompiling with the wrong options
+        withenv("JULIA_PKG_PRECOMPILE_AUTO" => false) do
+            Pkg.add(; package_spec...)
+        end
 
         println("\nCompleted after $(elapsed(t0))")
 


### PR DESCRIPTION
> https://github.com/JuliaLang/julia/pull/47184 will cause precompilation to occur again if certain flags (notably, checkbounds) are changed. So we wait to precompile until all flags are known.