### PR TITLE
Separate out precompilation

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -343,11 +343,16 @@ function evaluate_test(config::Configuration, pkg::Package; use_cache::Bool=true
             run(```$(Base.julia_cmd())
                    --check-bounds=yes
                    -e 'using Pkg
-                       Pkg.activate(; temp=true)
-                       Pkg.add("TestEnv")
-                       using TestEnv
-                       Pkg.activate()
-                       TestEnv.activate(ARGS[1])
+                       try
+                         Pkg.activate(; temp=true)
+                         Pkg.add("TestEnv")
+                         using TestEnv
+                         Pkg.activate()
+                         TestEnv.activate(ARGS[1])
+                       catch err
+                         @error "Failed to use TestEnv.jl; test dependencies will not be precompiled" exception=(err, catch_backtrace())
+                         Pkg.activate()
+                       end
                        Pkg.precompile()' $(package_spec.name)```)
 
             println("\nPrecompilation completed after $(elapsed(t0))")

--- a/src/sandbox.jl
+++ b/src/sandbox.jl
@@ -169,6 +169,10 @@ function setup_julia_sandbox(config::Configuration, args=``;
         "PKGEVAL" => "true",
         "JULIA_PKGEVAL" => "true",
 
+        # disable automatic precompilation on Pkg.add, because the generated images
+        # aren't usable for testing anyway (which runs with different options)
+        "JULIA_PKG_PRECOMPILE_AUTO" => "0",
+
         # use the provided registry
         # NOTE: putting a registry in a non-primary depot entry makes Pkg use it as-is,
         #       without needing to set Pkg.UPDATED_REGISTRY_THIS_SESSION.


### PR DESCRIPTION
Turns out https://github.com/JuliaCI/PkgEval.jl/pull/201 had a problem: because it resulted in precompilation happening during `Pkg.test`, it broke the test time measurement (which I intend to use as an ecosystem-wide performance regression test).

As an alternative approach, call `Pkg.precompile` manually again, but in a Julia shell we launched using the correct options (to avoid redundant compilation). @vchuravy which options exactly are relevant?

TODO: maybe add a test that on 1.9+ we only generate a single .so when testing, say, Example.jl
