### PR TITLE
stop skipping ArchGDAL

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -38,7 +38,6 @@ skip = [
     "Minuit2",              #
     "CDDLib",               # segfault in called library
     "Elemental",            #
-    "ArchGDAL",             #
     "Starlight",            #
 
     # requires specific environment


### PR DESCRIPTION
The problems from https://github.com/yeesian/ArchGDAL.jl/issues/347 seem to be all fixed and tagged now. I cannot run the PkgEval sandbox from WSL (`ERROR: Failed to start Xvfb`), but locally on 1.9.0-beta2 all tests pass.