### PR TITLE
Avoid GitHub rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,4 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/src/PkgEval.jl
+++ b/src/PkgEval.jl
@@ -3,6 +3,7 @@ module PkgEval
 using Pkg, LazyArtifacts
 import Pkg.TOML
 import GitHub
+using Base: UUID
 
 import Scratch: @get_scratch!
 download_dir = ""

--- a/src/types.jl
+++ b/src/types.jl
@@ -144,7 +144,7 @@ end
 Base.@kwdef struct Package
     # source of the package; forwarded to PackageSpec
     name::String
-    uuid::Union{Nothing,Base.UUID} = nothing
+    uuid::Union{Nothing,UUID} = nothing
     version::Union{Nothing,String,VersionNumber} = nothing
     url::Union{Nothing,String} = nothing
     rev::Union{Nothing,String} = nothing


### PR DESCRIPTION
By using a token, and checking out the registry from a PkgServer.