### PR TITLE
Only blacklist packages when testing the entire ecosystem.

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -922,6 +922,7 @@ The `ninstances` keyword argument determines how many packages are tested in par
 
 The `blacklist` keyword argument can be used to skip testing of packages, specified by name.
 The blacklist is always extended with a hard-coded set of packages known to be problematic.
+It is only used when no explicit list of packages is given.
 
 Refer to `evaluate_test`[@ref] and `sandboxed_julia`[@ref] for more possible keyword
 arguments.
@@ -932,6 +933,9 @@ function evaluate(configs::Vector{Configuration}, packages::Vector{Package}=Pack
     if isempty(packages)
         registry_configs = unique(config->config.registry, values(configs))
         packages = intersect(values.(map(get_packages, registry_configs))...)::Vector{Package}
+    else
+        # if we are given an explicit list of packages, ignore the blacklist
+        blacklist = String[]
     end
 
     # ensure the configurations have unique names

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,14 +161,6 @@ end
     end
 end
 
-@testset "blacklist" begin
-    let results = evaluate([config], [Package(; name="Example")];
-                           validate=false, retry=false, blacklist=["Example"])
-        @test size(results, 1) == 1
-        @test results[1, :status] == :skip && results[1, :reason] == :blacklisted
-    end
-end
-
 @testset "complex packages" begin
     # some more complicate packages that are all expected to pass tests
     package_names = ["TimerOutputs", "Crayons", "Example", "Gtk"]


### PR DESCRIPTION
This makes it possible to test blacklisted packages, when specifically requesting it.

cc @KristofferC 