### PR TITLE
Explicitly test the latest version of each package

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -941,10 +941,41 @@ arguments.
 function evaluate(configs::Vector{Configuration}, packages::Vector{Package}=Package[];
                   ninstances::Integer=Sys.CPU_THREADS, retry::Bool=true,
                   validate::Bool=true, blacklist::Vector{String}=String[])
+    result = DataFrame(configuration = String[],
+                       package = String[],
+                       version = Union{Missing,VersionNumber}[],
+                       status = Symbol[],
+                       reason = Union{Missing,Symbol}[],
+                       duration = Float64[],
+                       log = Union{Missing,String}[])
+    skips = similar(result)
+
+    # determine the packages to test
+    registry_configs = unique(config->config.registry, values(configs))
+    compatible_packages = intersect(values.(map(get_packages, registry_configs))...)
     if isempty(packages)
-        registry_configs = unique(config->config.registry, values(configs))
-        packages = intersect(values.(map(get_packages, registry_configs))...)::Vector{Package}
+        # only test packages for which the latest version is compatible with all configs
+        packages = compatible_packages
     else
+        # augment the packages with a version to ensure we test the same thing everywhere
+        package_map = Dict(package.name => package for package in compatible_packages)
+        packages = map(packages) do package
+            if package.version !== nothing || package.rev !== nothing || package.url !== nothing
+                # don't discard an explicitly-requested version
+                package
+            elseif haskey(package_map, package.name)
+                Package(package; version=package_map[package.name].version)
+            else
+                # couldn't find a compatible version in the registry...
+                for config in configs
+                    push!(skips, [config.name, package.name, missing,
+                                  :skip, :uninstallable, 0, missing])
+                end
+                nothing
+            end
+        end
+        packages = filter(!isnothing, packages)
+
         # if we are given an explicit list of packages, ignore the blacklist
         blacklist = String[]
     end
@@ -978,16 +1009,7 @@ function evaluate(configs::Vector{Configuration}, packages::Vector{Package}=Pack
     ## use a random test order to (hopefully) get a more reasonable ETA
     shuffle!(jobs)
 
-    result = DataFrame(configuration = String[],
-                       package = String[],
-                       version = Union{Missing,VersionNumber}[],
-                       status = Symbol[],
-                       reason = Union{Missing,Symbol}[],
-                       duration = Float64[],
-                       log = Union{Missing,String}[])
-
     # pre-filter the jobs for packages we'll skip to get a better ETA
-    skips = similar(result)
     jobs = filter(jobs) do job
         if endswith(job.package.name, "_jll")
             # JLLs we ignore completely; it's not useful to include them in the skip count

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -97,7 +97,25 @@ function _get_packages(config::Configuration)
     registry = get_registry(config)
     registry_instance = Pkg.Registry.RegistryInstance(registry)
     for (_, pkg) in registry_instance
-        # TODO: read package compat info so that we can avoid testing uninstallable packages
+        # for simplicity, we only consider the latest version of each package.
+        # this ensures we'll always test the same version across configurations.
+        #
+        # we could be smarter here and intersect the known versions of a package
+        # with each Julia version, but that's a lot more complicated.
+        info = Pkg.Registry.registry_info(pkg)
+        version = maximum(keys(info.version_info))
+
+        # check if this package is compatible with the current Julia version
+        compat = true
+        for (version_range, bounds) in info.compat
+            version in version_range || continue
+            if haskey(bounds, "julia") && julia_version(config) ∉ bounds["julia"]
+                compat = false
+                break
+            end
+        end
+        compat || continue
+
         packages[pkg.name] = Package(; pkg.name, pkg.uuid)
     end
 

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -116,7 +116,7 @@ function _get_packages(config::Configuration)
         end
         compat || continue
 
-        packages[pkg.name] = Package(; pkg.name, pkg.uuid)
+        packages[pkg.name] = Package(; pkg.name, pkg.uuid, version)
     end
 
     # merge both, preferring stdlib versions


### PR DESCRIPTION
Ideal would be looking up which version is compatible for the different Julia builds we're using, but this is much simpler. It ensures we always test the same code on each Julia version.

Fixes https://github.com/JuliaCI/PkgEval.jl/issues/208