### PR TITLE
Retry crashes under rr.

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -1104,7 +1104,8 @@ function evaluate(configs::Vector{Configuration}, packages::Vector{Package}=Pack
                     # retry it to see if we can get a trace for the crash.
                     # it's fine to do so separately here, because the
                     # retry block below will never retry crashes.
-                    if !job.config.rr && retry && status === :crash
+                    if status === :crash && haskey(ENV, "PKGEVAL_RR_BUCKET") &&
+                       !job.config.rr && retry
                         rr_config = Configuration(main_config; rr=true)
                         rr_results = evaluate_test(rr_config, job.package; job.use_cache)
 

--- a/src/julia.jl
+++ b/src/julia.jl
@@ -242,7 +242,7 @@ function build_julia!(config::Configuration, checkout::String)
     log = fetch(log_monitor)
 
     if success(proc)
-        @debug "Successfully build Julia:\n$log"
+        @debug "Successfully built Julia:\n$log"
         return install_dir
     else
         @error "Error building Julia:\n$log"

--- a/src/types.jl
+++ b/src/types.jl
@@ -37,7 +37,7 @@ Base.@kwdef struct Configuration
     julia::Setting{String} = Default("nightly")
     ## flags and commands to use to build Julia (this disables use of prebuilt binaries)
     buildflags::Setting{Vector{String}} = Default(String[])
-    buildcommands::Setting{String} = Default("make install")
+    buildcommands::Setting{String} = Default("make binary-dist")
     ## where to install Julia, and what the name of the generated binary is
     julia_install_dir::Setting{String} = Default("/opt/julia")
     julia_binary::Setting{String} = Default("julia")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,6 +75,9 @@ end
     end
 end
 
+@isdefined(julia_version) || error("Failed to build Julia")
+if @isdefined(julia_version)    # to prevent other tests from failing
+
 @testset "environment flags" begin
     let
         p = Pipe()
@@ -302,6 +305,8 @@ end
             @test contains(out, r"Example.*#master")
         end
     end
+end
+
 end
 
 PkgEval.purge()


### PR DESCRIPTION
If this works, I want to disable using `rr` for all tests in the daily evaluations. It's very expensive, and although this may result in us missing rare/nondeterministic crashes, I don't think we can keep up with the ecosystem growth if daily PkgEval runs already take over 12h.