### PR TITLE
Remove Fronts.jl blacklist

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -47,7 +47,6 @@ skip = [
     "SimJulia",
     "CCDReduction",
     "FoldRNA",
-    "Fronts",
     "QuantumSavory",
     "QuantumSavory",
     "OpenQuantumSystems",


### PR DESCRIPTION
@maleadt The latest release (v1.1.3) of `Fronts` no longer depends on `ResumableFunctions` (https://github.com/BenLauwens/ResumableFunctions.jl/issues/60)