### PR TITLE
Remove FoldRNA from Packages.toml skip list

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -46,7 +46,6 @@ skip = [
     "ResumableFunctions",
     "SimJulia",
     "CCDReduction",
-    "FoldRNA",
     "QuantumSavory",
     "QuantumSavory",
     "OpenQuantumSystems",


### PR DESCRIPTION
No longer depends on ResumableFunctions as of FoldRNA v0.1.1