### PR TITLE
remove ResumableFunctions and dependents from blacklist

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -41,19 +41,6 @@ skip = [
     "IBMQJulia",
     # using overly complex types/tuples
     "Salsa",
-    
-    # depends on ResumableFunctions.jl, which is broken
-    "ResumableFunctions",
-    "SimJulia",
-    "CCDReduction",
-    "QuantumSavory",
-    "QuantumSavory",
-    "OpenQuantumSystems",
-    "TopOpt",
-    "TopOptMakie",
-    "TopOptProblems",
-    "VTKDataTypes",
-    "VTKDataIO",
 
     # requires specific environment
     "AWSS3",                # AWS secrets


### PR DESCRIPTION
As reported in https://github.com/BenLauwens/ResumableFunctions.jl/issues/60 ResumableFunctions.jl was relying on internal julia implementation details that changed in 1.10. A fix is now upstreamed and released as non-breaking (v0.6.2).