### PR TITLE
Skip LoopThrottle.jl

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -41,6 +41,8 @@ skip = [
     "IBMQJulia",
     # using overly complex types/tuples
     "Salsa",
+    # sleep precision tests with tight upper bound
+    "LoopThrottle",
 
     # requires specific environment
     "AWSS3",                # AWS secrets


### PR DESCRIPTION
It's flakey (see: https://github.com/tkoolen/LoopThrottle.jl/issues/10, https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/94a56d2_vs_fb76136/LoopThrottle.primary.log) and hasn't been updated in years, but does have 11 dependants.