### PR TITLE
Re-enable pkgimages

### DIFF
--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -111,16 +111,6 @@ function evaluate_script(config::Configuration, script::String, args=``;
         env["JULIA_PKG_SERVER"] = ENV["JULIA_PKG_SERVER"]
     end
 
-    version = julia_version(config)
-    if version >= v"1.10.0-DEV.204" || v"1.9.0-alpha1.55" <= version < v"1.10-"
-        # package images are really expensive, and significantly regress PkgEval time.
-        # for now, disable them (unless the user specifically requested them).
-        if !any(startswith("--pkgimages"), config.julia_flags)
-            config =
-                Configuration(config; julia_flags=[config.julia_flags..., "--pkgimages=no"])
-        end
-    end
-
     input = Pipe()
     output = Pipe()
     args = `-e 'include_string(Main, read(stdin,String))' --color=no $args`

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -87,7 +87,9 @@ function _get_packages(config::Configuration)
     proc = sandboxed_julia(config, `-e $stdlib_script`; stdout=p.out)
     while !eof(p.out)
         line = readline(p.out)
-        uuid, name = split(line, ' ')
+        entries = split(line, ' ')
+        length(entries) == 2 || continue
+        uuid, name = entries
         stdlibs[name] = Package(; name, uuid=UUID(uuid))
     end
     success(proc) || error("Failed to list standard libraries")


### PR DESCRIPTION
Now that Pkg has been removed from the sysimg, we need to use pkgimages or every Pkg operation will be slow and cause a lot of compilation.

cc @KristofferC 