### PR TITLE
Add support for building the 'stable' version.

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,6 +36,14 @@ function get_github_checkout(repo, ref)
         ref, nothing
     end
 
+    # special case: "stable", where we use the latest release tag
+    if ref == "stable"
+        tags = split(read(`$(git()) -C $clone tag`, String))
+        filter!(t -> startswith(t, "v"), tags)
+        filter!(t -> !occursin(r"-", t), tags)
+        ref = sort(tags, by=VersionNumber) |> last
+    end
+
     # explicitly fetch the requested commit from the remote and put it on the master branch.
     # we need to do this as not all specs (e.g. `pull/42/merge`) might be available locally
     run(`$(git()) -C $clone fetch --quiet --force origin $ref:master`)


### PR DESCRIPTION
The `stable` name is used for package testing, but since Nanosoldier now also requests assertions to be enabled (https://github.com/JuliaCI/Nanosoldier.jl/pull/183) that gets passed to the build functionality. Make sure that knows how to deal with `stable` by looking up the latest tag.