### PR TITLE
Add Revise's dependencies to "important packages"

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -80,7 +80,7 @@ skip_rr = [
 # packages that are important, and thus shouldn't ever be blacklisted
 important = [
     "BenchmarkTools",
-    "CodeTracking",
+    "CodeTracking", # used by Revise
     "DataFrames",
     "DifferentialEquations",
     "Flux",

--- a/Packages.toml
+++ b/Packages.toml
@@ -80,6 +80,7 @@ skip_rr = [
 # packages that are important, and thus shouldn't ever be blacklisted
 important = [
     "BenchmarkTools",
+    "CodeTracking",
     "DataFrames",
     "DifferentialEquations",
     "Flux",
@@ -87,6 +88,7 @@ important = [
     "JuliaInterpreter",
     "JuMP",
     "LLVM",
+    "LoweredCodeUtils",
     "Plots",
     "Revise",
 ]

--- a/Packages.toml
+++ b/Packages.toml
@@ -88,7 +88,7 @@ important = [
     "JuliaInterpreter",
     "JuMP",
     "LLVM",
-    "LoweredCodeUtils",
+    "LoweredCodeUtils", # used by Revise
     "Plots",
     "Revise",
 ]


### PR DESCRIPTION
Julia 1.10 was released while still breaking CodeTracking (due to a parser change, https://github.com/JuliaLang/JuliaSyntax.jl/issues/316#issuecomment-1870294857). I was deliberately not fixing this issue assuming it would be noticed and investigated during the 1.10 PkgEval runs, but it seems to have either been decided to be unimportant or simply not noticed. EDIT: LoweredCodeUtils tests are broken, too.

While this is not actually a big deal, given that these packages both underlie Revise and extensively test internals, perhaps it makes sense to ensure they don't get blacklisted.
