### PR TITLE
rr-related improvements

### DIFF
--- a/scripts/precompile.jl
+++ b/scripts/precompile.jl
@@ -6,7 +6,9 @@ pkg = eval(Meta.parse(ARGS[2]))
 Pkg.activate("pkgeval"; shared=true)
 
 # precompile PkgEval run-time dependencies (notably BugReporting.jl)
+println("Precompiling PkgEval dependencies...")
 Pkg.precompile()
+println()
 
 # try to use TestEnv to precompile the package test dependencies
 try
@@ -17,4 +19,6 @@ catch err
     @error "Failed to use TestEnv.jl; test dependencies will not be precompiled" exception=(err, catch_backtrace())
     Pkg.activate()
 end
+
+println("Precompiling $(pkg.name) dependencies...")
 Pkg.precompile()

--- a/scripts/report_bug.jl
+++ b/scripts/report_bug.jl
@@ -9,13 +9,25 @@ t0 = cpu_time()
 try
     # use a clean environment, or BugReporting's deps could
     # affect/be affected by the tested package's dependencies.
-    Pkg.activate(; temp=true)
-    Pkg.add(name="BugReporting", uuid="bcf9a6e7-4020-453c-b88e-690564246bb8")
+    io = IOBuffer()
+    Pkg.DEFAULT_IO[] = io
+    try
+        Pkg.activate(; temp=true)
+        Pkg.add(name="BugReporting", uuid="bcf9a6e7-4020-453c-b88e-690564246bb8")
+    catch
+        # something went wrong installing BugReporting.jl
+        println(String(take!(io)))
+        rethrow()
+    finally
+        Pkg.DEFAULT_IO[] = nothing
+    end
     using BugReporting
 
+    println("Finalizing trace...")
     trace_dir = BugReporting.default_rr_trace_dir()
     trace = BugReporting.find_latest_trace(trace_dir)
     BugReporting.compress_trace(trace, "/output/$(pkg.name).tar.zst")
+
     println("\nBugReporting completed after $(elapsed(t0))")
 catch err
     println("\nBugReporting failed after $(elapsed(t0))")

--- a/scripts/test.jl
+++ b/scripts/test.jl
@@ -63,7 +63,19 @@ else
     end
 end
 
-Pkg.add(deps)
+io = IOBuffer()
+Pkg.DEFAULT_IO[] = io
+try
+    println("Installing PkgEval dependencies...")
+    Pkg.add(deps)
+    println()
+catch
+    # something went wrong installing PkgEval's dependencies
+    println(String(take!(io)))
+    rethrow()
+finally
+    Pkg.DEFAULT_IO[] = nothing
+end
 
 Pkg.activate()
 

--- a/scripts/test.jl
+++ b/scripts/test.jl
@@ -35,6 +35,7 @@ if config.rr == RREnabled
         println(io, "using BugReporting")
         println(io, "println(\"Switching execution to under rr\")")
         println(io, "BugReporting.make_interactive_report(\"rr-local\", ARGS)")
+        println(io, "exit(0)")
     end
 end
 

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -941,6 +941,16 @@ function evaluate(configs::Vector{Configuration}, packages::Vector{Package}=Pack
                             # if the rr test crashed in the same way, use that evaluation
                             if rr_results.status === status && rr_results.reason === reason
                                 (; log, status, reason, version, duration, input_output) = rr_results
+                            else
+                                log *= "\n\n" * '#'^80 * "\n# Bug reporting\n#\n\n"
+                                log *= """The package crashed during testing (reason=$reason), but PkgEval was unable to
+                                          reproduce the crash under rr (status=$(rr_results.status), reason=$(rr_results.reason)).
+
+                                          For debugging, here is the tail end of the rr log:"""
+                                log *= "\n\n"
+                                for line in last(eachline(IOBuffer(rr_results.log)), 100)
+                                    log *= "> $line\n"
+                                end
                             end
                         end
                     end


### PR DESCRIPTION
If the test process succeeded, we would re-execute the tests. Avoid that by including an `exit(0)`.

However, PkgEval proper doesn't seem to collect rr traces anymore. I've included some logging to debug that.

Also hides some irrelevant Pkg output by overriding `Pkg.DEFAULT_IO`. Hope that's portable...