### PR TITLE
Skip `UnitfulRecipes`

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -15,6 +15,7 @@ skip = [
     "AMDGPUnative",
     "ROCArrays",
     "GPUifyLoops",
+    "UnitfulRecipes",
 
     # requires binaries
     "MATLAB",               # MATLAB


### PR DESCRIPTION
This is an old and unmaintained package (https://github.com/jw3126/UnitfulRecipes.jl/pull/81), so even if we had to fix anything in that package, nothing could be done about it.  Note: this is currently failing tests in https://github.com/JuliaLang/julia/pull/53891#issuecomment-2040626771 because it's trying to install a very ancient version of `GR.jl`, I don't see any fix possible if the package is deprecated.