### PR TITLE
Add PackageCompiler to the "important package" list

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -105,6 +105,7 @@ important = [
     "LoweredCodeUtils", # used by Revise
     "Plots",
     "Revise",
+    "PackageCompiler",
 ]
 
 # packages that are slow, and should be granted more test time (they're worth it)


### PR DESCRIPTION
I'd like to propose that we add [PackageCompiler.jl](https://github.com/JuliaLang/PackageCompiler.jl) to the list of "important packages" for PkgEval.