### PR TITLE
Forward Julia arguments to Pkg.test

### DIFF
--- a/scripts/compile.jl
+++ b/scripts/compile.jl
@@ -12,7 +12,7 @@ versioninfo()
 
 
 print("\n\n", '#'^80, "\n# Installation\n#\n\n")
-t0 = time()
+t0 = cpu_time()
 
 is_stdlib = any(Pkg.Types.stdlibs()) do (uuid,stdlib)
     name = isa(stdlib, String) ? stdlib : first(stdlib)
@@ -35,7 +35,7 @@ println("\nCompleted after $(elapsed(t0))")
 
 
 print("\n\n", '#'^80, "\n# Compilation\n#\n\n")
-t1 = time()
+t1 = cpu_time()
 
 create_sysimage([pkg.name]; sysimage_path)
 println("\nCompleted after $(elapsed(t1))")

--- a/scripts/test.jl
+++ b/scripts/test.jl
@@ -46,7 +46,7 @@ end
 julia_args = if VERSION < v"1.9-beta1" || (v"1.10-" <= VERSION < v"1.10.0-DEV.204")
     # we don't support pkgimages yet
     ``
-elseif any(startswith("--pkgimages"), config.julia_flags)
+elseif any(startswith("--pkgimages"), config.julia_args)
     # the user specifically requested pkgimages
     ``
 else

--- a/scripts/test.jl
+++ b/scripts/test.jl
@@ -43,26 +43,32 @@ end
 # generating package images is really expensive, without much benefit (for PkgEval)
 # so determine here if we need to disable them using additional CLI args
 # (we can't do this externally because of JuliaLang/Pkg.jl#3737)
-julia_args = if VERSION < v"1.9-beta1" || (v"1.10-" <= VERSION < v"1.10.0-DEV.204")
+julia_args = String[]
+if VERSION < v"1.9-beta1" || (v"1.10-" <= VERSION < v"1.10.0-DEV.204")
     # we don't support pkgimages yet
-    ``
 elseif any(startswith("--pkgimages"), config.julia_args)
     # the user specifically requested pkgimages
-    ``
 else
     if VERSION >= v"1.11-DEV.1119"
         # we can selectively disable pkgimages while allowing reuse of existing ones
-        `--pkgimages=existing`
+        push!(julia_args, "--pkgimages=existing")
     elseif VERSION >= v"1.11-DEV.123"
         # we can only selectively disable all compilation caches. this isn't ideal,
         # but at this point in time (where many stdlibs have been moved out of the
         # system image) it's strictly better than using `--pkgimages=no`
-        `--compiled-modules=existing`
+        push!(julia_args, "--compiled-modules=existing")
     else
         # completely disable pkgimages
-        `--pkgimages=no`
+        push!(julia_args, "--pkgimages=no")
     end
 end
+
+# forward all user-provided flags to `Pkg.test` to ensure the test environment uses them.
+# we need to do so because Pkg inserts its own flags we want to be able to override (e.g.,
+# `--check-bounds`), and because its use of `Base.julia_cmd()` doesn't include all flags
+# passed to the current Julia process (e.g. `--inline`).
+append!(julia_args, config.julia_args)
+julia_args = Cmd(julia_args)
 
 io = IOBuffer()
 Pkg.DEFAULT_IO[] = io

--- a/src/PkgEvalCore.jl
+++ b/src/PkgEvalCore.jl
@@ -57,7 +57,7 @@ Base.@kwdef struct Configuration
     julia_install_dir::Setting{String} = Default("/opt/julia")
     julia_binary::Setting{String} = Default("julia")
     ## additional Julia arguments to pass to the process
-    julia_flags::Setting{Vector{String}} = Default(String[])
+    julia_args::Setting{Vector{String}} = Default(String[])
 
     # registry properties
     ## the repo spec of the registry to use
@@ -132,7 +132,7 @@ function Base.show(io::IO, ::MIME"text/plain", cfg::Configuration)
     println(io, "PkgEval configuration '$(cfg.name)' (")
 
     println(io, "  # Julia properties")
-    show_setting.(["julia", "buildflags", "buildcommands", "julia_install_dir", "julia_binary", "julia_flags"])
+    show_setting.(["julia", "buildflags", "buildcommands", "julia_install_dir", "julia_binary", "julia_args"])
     println(io)
 
     println(io, "  # Registry properties")

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -609,7 +609,7 @@ function evaluate_compiled_test(config::Configuration, pkg::Package;
     compile_log = log
     test_config = Configuration(config;
         compiled = false,
-        julia_flags = [config.julia_flags..., "--sysimage", sysimage_path],
+        julia_args = [config.julia_args..., "--sysimage", sysimage_path],
     )
     (; log, status, reason, version, duration, input_output) =
         evaluate_test(test_config, pkg; mounts, use_cache, kwargs...)

--- a/src/sandbox.jl
+++ b/src/sandbox.jl
@@ -368,7 +368,7 @@ function setup_julia_sandbox(config::Configuration, args=``;
     # configure threads
     env["JULIA_NUM_THREADS"] = string(config.threads)
 
-    setup_generic_sandbox(config, `$cmd $(Cmd(config.julia_flags)) $args`;
+    setup_generic_sandbox(config, `$cmd $(Cmd(config.julia_args)) $args`;
                           env, mounts, kwargs...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,7 +148,7 @@ end
 
 if julia_version >= v"1.10.0-DEV.204" || v"1.9.0-alpha1.55" <= julia_version < v"1.10-"
 @testset "package precompilation" begin
-    let config = Configuration(config; julia_flags=["--pkgimages=yes"])
+    let config = Configuration(config; julia_args=["--pkgimages=yes"])
         # find out where Example.jl will be precompiled
         verstr = "v$(julia_version.major).$(julia_version.minor)"
         compilecache = joinpath(PkgEval.get_compilecache(config), verstr, "Example")


### PR DESCRIPTION
This defeats Pkg.jl's `gen_subprocess_cmd` overriding flags like `--check-bounds` with an unconditional `yes`, as well as `Base.julia_cmd` not reporting flags like `--inline`. With this, it should be possible to run PkgEval with `--check-bounds=no`, as requested in https://github.com/JuliaLang/julia/pull/55913.