### PR TITLE
Blacklist ScanByte.jl

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -53,6 +53,7 @@ skip = [
     "FITSIO",
     "OIFITS",
     "CFITSIO",
+    "ScanByte",
 
     # requires specific environment
     "AWSS3",                # AWS secrets


### PR DESCRIPTION
This is one of my packages. It does some pointer stuff that's illegal (which I didn't know was), and so started segfaulting on 1.11. E.g. [here, segfaulting on a recent PkgEval run](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/790081c_vs_4976d05/report.html).
Ideally I'd just fix the package, but it's turned out to be harder than I expected, so blacklisting it for now.