### PR TITLE
Remove CFITSIO and FITSIO from skipped packages

### DIFF
--- a/Packages.toml
+++ b/Packages.toml
@@ -50,9 +50,7 @@ skip = [
     # generating way too much output
     "OptimKit",
     # unsafe pointer handling
-    "FITSIO",
     "OIFITS",
-    "CFITSIO",
     "ScanByte",
 
     # requires specific environment


### PR DESCRIPTION
The issues with these packages should be fixed in recent versions. `FITSIO.jl` does not handle unsafe pointers anymore, and the segfaults in `CFITSIO.jl` have been fixed.