### PR TITLE
Fix `get_kernel_version()` on RHEL derivatives

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -355,6 +355,7 @@ function get_kernel_version()
         kver = tryparse(VersionNumber, kver_str)
         if kver === nothing
             # Regex for RHEL derivatives:
+            # https://github.com/JuliaCI/PkgEval.jl/pull/287
             r = r"^(\d*?\.\d*?\.\d*?)-[\w\d._]*?$"
             m = match(r, kver_str)
             if m isa RegexMatch

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -351,7 +351,7 @@ const kernel_version = Ref{Union{VersionNumber,Missing}}()
 function get_kernel_version()
     if !isassigned(kernel_version)
         kver_str = strip(read(`/bin/uname -r`, String))
-        kver = parse_kernel_version(str)
+        kver = parse_kernel_version(kver_str)
         kernel_version[] = something(kver, missing)
     end
     return kernel_version[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,14 @@ buildflags = get(ENV, "BUILDFLAGS", "")
 cgroup_controllers = PkgEval.get_cgroup_controllers()
 @info "Available cgroup controllers: $(isempty(cgroup_controllers) ? "none" : join(cgroup_controllers, ", "))"
 
+@testset "Misc quick tests" begin
+    @test PkgEval.parse_kernel_version("1.2.3") == v"1.2.3"
+
+    # RHEL derivatives
+    # https://github.com/JuliaCI/PkgEval.jl/pull/287
+    @test PkgEval.parse_kernel_version("4.18.0-553.60.1.el8_10.x86_64") == v"4.18.0"
+end
+
 @testset "Configuration" begin
     # default object: nothing modified
     x = Configuration()


### PR DESCRIPTION
On RHEL derivatives, here is example output for `uname -r`:

```
$ uname -r
4.18.0-553.60.1.el8_10.x86_64
```

This PR makes it so that `get_kernel_version()` can parse that kind of output.